### PR TITLE
Fix RedisCache set function 

### DIFF
--- a/src/redis-cache.ts
+++ b/src/redis-cache.ts
@@ -34,10 +34,10 @@ const RedisCache = ({ client }: IRedisCacheOptions): IYokeCacheDriver => {
       milliseconds?: number,
     ): Promise<void> => {
       if (milliseconds) {
-        const seconds = milliseconds / 1000
+        const seconds = Math.floor(milliseconds / 1000)
         await setExAsync(key, seconds, value)
-      }
-
+        return
+      } 
       await setAsync(key, value)
     },
 


### PR DESCRIPTION
1. redis-client set function should be invoked only once, otherwise the ttl won't work as expected.
2. ttl should be an integer. 